### PR TITLE
Add XROS platform to scrape-from-xcode scripts

### DIFF
--- a/.github/workflows/json_format.yml
+++ b/.github/workflows/json_format.yml
@@ -23,11 +23,9 @@ jobs:
 
       - name: Format JSON files
         run: |
-          npx jsonlint -i ios-device-identifiers.json
-          npx jsonlint -i tvos-device-identifiers.json
-          npx jsonlint -i watchos-device-identifiers.json
-          npx jsonlint -i mac-device-identifiers.json
-          npx jsonlint -i mac-device-identifiers-unique.json
+          for file in *.json; do
+            npx jsonlint -i "$file"
+          done
 
       - name: Check JSON files have changed
         run: |

--- a/.github/workflows/xcode-scrapper.yml
+++ b/.github/workflows/xcode-scrapper.yml
@@ -9,7 +9,7 @@ jobs:
   scrap:
     # update to newer version when available
     # https://github.com/actions/runner-images#available-images
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
       - name: Check out Git repository

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # apple-device-identifiers
 
-JSON files for mapping iOS, iPadOS, tvOS, watchOS, and macOS device identifiers to some human readable equivalent.
+JSON files for mapping iOS, iPadOS, tvOS, watchOS, visionOS and macOS device identifiers to some human readable equivalent.
 
 ## Usage
 
@@ -15,7 +15,7 @@ Here is a simple example using the JSON file with bash and [jq](https://stedolan
 ```shell
 function get_apple_device_name() {
   local URL="https://raw.githubusercontent.com/kyle-seongwoo-jun/apple-device-identifiers/main"
-  local OS="$1" # ios, tvos, watchos, mac
+  local OS="$1" # ios, tvos, watchos, visionos, mac
   local IDENTIFIER="$2"
   curl "$URL/$OS-device-identifiers.json" | jq -r ".[\"$IDENTIFIER\"]"
 }
@@ -30,7 +30,7 @@ MacBook Pro (16-inch, Nov 2023)
 ## Genrerate JSON file
 
 ```shell
-# iOS, iPadOS, tvOS, watchOS
+# iOS, iPadOS, tvOS, watchOS, visionOS
 deno run --allow-run --allow-read --allow-write scripts/scrape-from-xcode.ts
 
 # macOS

--- a/scripts/scrape-from-xcode.sh
+++ b/scripts/scrape-from-xcode.sh
@@ -9,7 +9,7 @@
 # Requires sqlite3: https://www.sqlite.org/index.html
 # Tested with Xcode 14.3.1
 
-# Platform: iPhoneOS | AppleTVOS | WatchOS
+# Platform: iPhoneOS | AppleTVOS | WatchOS | XROS
 PLATFORM=$1
 
 if [ -z "$PLATFORM" ]; then
@@ -17,7 +17,7 @@ if [ -z "$PLATFORM" ]; then
     exit 1
 fi
 
-if [ "$PLATFORM" != "iPhoneOS" ] && [ "$PLATFORM" != "AppleTVOS" ] && [ "$PLATFORM" != "WatchOS" ]; then
+if [ "$PLATFORM" != "iPhoneOS" ] && [ "$PLATFORM" != "AppleTVOS" ] && [ "$PLATFORM" != "WatchOS" ] && [ "$PLATFORM" != "XROS" ]; then
     echo "Error: Invalid platform: $PLATFORM"
     exit 1
 fi

--- a/scripts/scrape-from-xcode.ts
+++ b/scripts/scrape-from-xcode.ts
@@ -47,6 +47,7 @@ const platforms = [
     { name: "iPhoneOS", file: "ios-device-identifiers.json" },
     { name: "WatchOS", file: "watchos-device-identifiers.json" },
     { name: "AppleTVOS", file: "tvos-device-identifiers.json" },
+    { name: "XROS", file: "visionos-device-identifiers.json" },
 ];
 await Promise.all(platforms.map((p) => generateJsonFile(p)));
 

--- a/visionos-device-identifiers.json
+++ b/visionos-device-identifiers.json
@@ -1,0 +1,3 @@
+{
+  "RealityDevice14,1": "Apple Vision Pro"
+}


### PR DESCRIPTION
This pull request adds support for the XROS platform to the scrape-from-xcode scripts. It also updates the device identifiers for visionOS in the README.md file.